### PR TITLE
Moving to new `jaxdf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed arguments error in helmholtz notebook
 
 ### Changed
-- `Medium` objects are now `JaxDFModule`s, which is based on `equinox` modules. It is also a [parametric module for dispatching operators](https://beartype.github.io/plum/parametric.html), meaning that there's a type difference betwee `Medium[FourierSeries]` and `Medium[FiniteDifferences]`, for example.
+- `Medium` objects are now `jaxdf.Module`s, which is based on `equinox` modules. It is also a [parametric module for dispatching operators](https://beartype.github.io/plum/parametric.html), meaning that there's a type difference betwee `Medium[FourierSeries]` and `Medium[FiniteDifferences]`, for example.
 - The settings of time domain acoustic simulations are now set using a `TimeWavePropagationSettings`. This also includes an attribute to explicity set the reference sound speed.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed arguments error in helmholtz notebook
 
 ### Changed
-- `Medium` objects are now `JaxDFModule`s, which is based on `equinox` modules. It is also a [parametric module for dispatching operators](https://beartype.github.io/plum/parametric.html), meaning that there's a type difference betwee `Medium[FourierSeries` and `Medium[FiniteDifferences]`, for example.
+- `Medium` objects are now `JaxDFModule`s, which is based on `equinox` modules. It is also a [parametric module for dispatching operators](https://beartype.github.io/plum/parametric.html), meaning that there's a type difference betwee `Medium[FourierSeries]` and `Medium[FiniteDifferences]`, for example.
 
 ### Added
 - Added a logger in `jwave.logger`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - `Medium` objects are now `JaxDFModule`s, which is based on `equinox` modules. It is also a [parametric module for dispatching operators](https://beartype.github.io/plum/parametric.html), meaning that there's a type difference betwee `Medium[FourierSeries]` and `Medium[FiniteDifferences]`, for example.
+- The settings of time domain acoustic simulations are now set using a `TimeWavePropagationSettings`. This also includes an attribute to explicity set the reference sound speed.
 
 ### Added
 - Added a logger in `jwave.logger`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fixed arguments error in helmholtz notebook
 
+### Changed
+- `Medium` objects are now `JaxDFModule`s, which is based on `equinox` modules. It is also a [parametric module for dispatching operators](https://beartype.github.io/plum/parametric.html), meaning that there's a type difference betwee `Medium[FourierSeries` and `Medium[FiniteDifferences]`, for example.
+
+### Added
+- Added a logger in `jwave.logger`
+
+### Removed
+- Removed `pressure_from_density` from `jwave.acoustics.conversion`, as it was a duplicate
+
 ## [0.1.5] - 2023-09-27
 ### Added
 - Added `numbers_with_smallest_primes` utility to find grids with small primes for efficient FFT when using FourierSeries

--- a/jwave/acoustics/conversion.py
+++ b/jwave/acoustics/conversion.py
@@ -16,29 +16,6 @@
 import numpy as np
 from jax import numpy as jnp
 
-from jwave.geometry import Sensors
-
-
-def pressure_from_density(sensors_data: jnp.ndarray, sound_speed: jnp.ndarray,
-                          sensors: Sensors) -> jnp.ndarray:
-    r"""
-    Calculate pressure from acoustic density given by the raw output of the
-    timestepping scheme.
-
-    Args:
-        sensors_data: Raw output of the timestepping scheme.
-        sound_speed: Sound speed of the medium.
-        sensors: Sensors object.
-
-    Returns:
-        jnp.ndarray: Pressure time traces at sensor locations
-    """
-    if sensors is None:
-        return jnp.sum(sensors_data[1], -1) * (sound_speed**2)
-    else:
-        return jnp.sum(sensors_data[1], -1) * (sound_speed[sensors.positions]**
-                                               2)
-
 
 def db2neper(
     alpha: jnp.ndarray,

--- a/jwave/acoustics/time_harmonic.py
+++ b/jwave/acoustics/time_harmonic.py
@@ -185,9 +185,9 @@ def _cbs_norm_units(medium, omega, k0, src):
     # Update fields
     src = FourierSeries(src.on_grid, domain)
     if issubclass(type(medium.sound_speed), FourierSeries):
-        medium.sound_speed = FourierSeries(c, domain)
-    else:
-        medium.sound_speed = c
+        c = FourierSeries(c, domain)
+
+    medium = medium.replace("sound_speed", c)
 
     # Update k0
     k0 = k0 * _conversion["dx"]

--- a/jwave/acoustics/time_varying.py
+++ b/jwave/acoustics/time_varying.py
@@ -13,16 +13,17 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with j-Wave. If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Dict, Tuple, TypeVar, Union
+from typing import Callable, Dict, Tuple, TypeVar, Union
 
+import equinox as eqx
 import numpy as np
 from jax import checkpoint as jax_checkpoint
 from jax import numpy as jnp
 from jax.lax import scan
 from jaxdf import Field, operator
 from jaxdf.discretization import FourierSeries, Linear, OnGrid
-from jaxdf.operators import (diag_jacobian, functional, shift_operator,
-                             sum_over_dims)
+from jaxdf.mods import JaxDFModule
+from jaxdf.operators import diag_jacobian, shift_operator, sum_over_dims
 
 from jwave.acoustics.spectral import kspace_op
 from jwave.geometry import Medium, Sources, TimeAxis
@@ -32,6 +33,55 @@ from jwave.signal_processing import smooth
 from .pml import td_pml_on_grid
 
 Any = TypeVar("Any")
+
+
+class TimeWavePropagationSettings(JaxDFModule):
+    """
+    TimeWavePropagationSettings configures the settings for
+    time domain wave solvers. This class serves as a container
+    for settings that influence how wave propagation is
+    simulated.
+
+    !!! example
+    ```python
+    >>> settings = TimeWavePropagationSettings(
+    ...    c_ref = lambda m: m.min_sound_speed)
+    >>> print(settings.checkpoint)
+    True
+    ```
+    """
+
+    c_ref: Callable = eqx.field(static=True)
+    checkpoint: bool = eqx.field(static=True)
+    smooth_initial: bool = eqx.field(static=True)
+
+    def __init__(
+        self,
+        c_ref: Callable = lambda m: m.max_sound_speed,
+        checkpoint: bool = True,
+        smooth_initial: bool = True,
+    ):
+        """
+        Initializes a new instance of the TimeWavePropagationSettings class.
+
+        Args:
+            c_ref (Callable, static): A callable that determines
+                the reference speed of the wave solver. This is a
+                expected to be a function that takes the `medium`
+                variable and returns the reference sound speed
+            checkpoint (bool, static): Flag indicating whether to
+                use checkpointing to save memory during backpropagation.
+                Defaults to True.
+            smooth_initial (bool, static): Flag to determine
+                whether to smooth initial pressure and velocity
+                fields. Defaults to True.
+        """
+        self.c_ref = c_ref
+        self.checkpoint = checkpoint
+        self.smooth_initial = smooth_initial
+
+
+default_time_wave_prop_settings = TimeWavePropagationSettings()
 
 
 def _shift_rho(rho0, direction, dx):
@@ -250,40 +300,6 @@ def pressure_from_density(rho: Field, medium: Medium, *, params=None) -> Field:
     return (c0**2) * rho_sum
 
 
-def ongrid_wave_prop_params(
-    medium: OnGrid,
-    time_axis: TimeAxis,
-    *args,
-    **kwargs,
-):
-    # Check which elements of medium are a field
-    x = [
-        x for x in [medium.sound_speed, medium.density, medium.attenuation]
-        if isinstance(x, Field)
-    ][0]
-
-    dt = time_axis.dt
-    c_ref = functional(medium.sound_speed)(jnp.amax)
-
-    # Making PML on grid for rho and u
-    def make_pml(staggering=0.0):
-        pml_grid = td_pml_on_grid(medium,
-                                  dt,
-                                  c0=c_ref,
-                                  dx=medium.domain.dx[0],
-                                  coord_shift=staggering)
-        pml = x.replace_params(pml_grid)
-        return pml
-
-    pml_rho = make_pml()
-    pml_u = make_pml(staggering=0.5)
-
-    return {
-        "pml_rho": pml_rho,
-        "pml_u": pml_u,
-    }
-
-
 @operator
 def wave_propagation_symplectic_step(
     p: Linear,
@@ -322,18 +338,54 @@ def wave_propagation_symplectic_step(
     return [p, u, rho]
 
 
-@operator
+def ongrid_wave_prop_params(
+    medium: OnGrid,
+    time_axis: TimeAxis,
+    *,
+    settings: TimeWavePropagationSettings,
+    **kwargs,
+):
+    # Check which elements of medium are a field
+    x = [
+        x for x in [medium.sound_speed, medium.density, medium.attenuation]
+        if isinstance(x, Field)
+    ][0]
+
+    dt = time_axis.dt
+
+    # Use settings to determine reference sound speed
+    c_ref = settings.c_ref(medium)
+
+    # Making PML on grid for rho and u
+    def make_pml(staggering=0.0):
+        pml_grid = td_pml_on_grid(medium,
+                                  dt,
+                                  c0=c_ref,
+                                  dx=medium.domain.dx[0],
+                                  coord_shift=staggering)
+        pml = x.replace_params(pml_grid)
+        return pml
+
+    pml_rho = make_pml()
+    pml_u = make_pml(staggering=0.5)
+
+    return {
+        "pml_rho": pml_rho,
+        "pml_u": pml_u,
+        "c_ref": c_ref,
+    }
+
+
+@operator(init_params=ongrid_wave_prop_params)
 def simulate_wave_propagation(
     medium: Medium[OnGrid],
     time_axis: TimeAxis,
     *,
+    settings: TimeWavePropagationSettings = default_time_wave_prop_settings,
     sources=None,
     sensors=None,
     u0=None,
     p0=None,
-    checkpoint: bool = True,
-    max_unroll_checkpoint: int = 10,
-    smooth_initial=True,
     params=None,
 ):
     r"""Simulate the wave propagation operator.
@@ -371,12 +423,9 @@ def simulate_wave_propagation(
     # Setup parameters
     output_steps = jnp.arange(0, time_axis.Nt, 1)
     dt = time_axis.dt
-    c_ref = functional(medium.sound_speed)(jnp.amax)
-
-    if params == None:
-        params = ongrid_wave_prop_params(medium, time_axis)
 
     # Get parameters
+    c_ref = params["c_ref"]
     pml_rho = params["pml_rho"]
     pml_u = params["pml_u"]
 
@@ -394,7 +443,7 @@ def simulate_wave_propagation(
     if p0 is None:
         p0 = pml_rho.replace_params(jnp.zeros(shape_one))
     else:
-        if smooth_initial:
+        if settings.smooth_initial:
             p0_params = p0.params[..., 0]
             p0_params = jnp.expand_dims(smooth(p0_params), -1)
             p0 = p0.replace_params(p0_params)
@@ -433,7 +482,7 @@ def simulate_wave_propagation(
         p = pressure_from_density(rho, medium)
         return [p, u, rho], sensors(p, u, rho)
 
-    if checkpoint:
+    if settings.checkpoint:
         scan_fun = jax_checkpoint(scan_fun)
 
     logger.debug("Starting simulation using generic OnGrid code")
@@ -445,11 +494,14 @@ def simulate_wave_propagation(
 def fourier_wave_prop_params(
     medium: Medium[FourierSeries],
     time_axis: TimeAxis,
-    *args,
+    *,
+    settings: TimeWavePropagationSettings,
     **kwargs,
 ):
     dt = time_axis.dt
-    c_ref = functional(medium.sound_speed)(jnp.amax)
+
+    # Use settings to determine reference sound speed
+    c_ref = settings.c_ref(medium)
 
     # Making PML on grid for rho and u
     def make_pml(staggering=0.0):
@@ -471,6 +523,7 @@ def fourier_wave_prop_params(
         "pml_rho": pml_rho,
         "pml_u": pml_u,
         "fourier": fourier,
+        "c_ref": c_ref
     }
 
 
@@ -479,13 +532,11 @@ def simulate_wave_propagation(
     medium: Medium[FourierSeries],
     time_axis: TimeAxis,
     *,
+    settings: TimeWavePropagationSettings = default_time_wave_prop_settings,
     sources=None,
     sensors=None,
     u0=None,
     p0=None,
-    checkpoint: bool = True,
-    max_unroll_checkpoint: int = 10,
-    smooth_initial=True,
     params=None,
 ):
     r"""Simulates the wave propagation operator using the PSTD method. This
@@ -524,11 +575,9 @@ def simulate_wave_propagation(
     # Setup parameters
     output_steps = jnp.arange(0, time_axis.Nt, 1)
     dt = time_axis.dt
-    c_ref = functional(medium.sound_speed)(jnp.amax)
-    if params == None:
-        params = fourier_wave_prop_params(medium, time_axis)
 
     # Get parameters
+    c_ref = params["c_ref"]
     pml_rho = params["pml_rho"]
     pml_u = params["pml_u"]
 
@@ -546,7 +595,7 @@ def simulate_wave_propagation(
     if p0 is None:
         p0 = pml_rho.replace_params(jnp.zeros(shape_one))
     else:
-        if smooth_initial:
+        if settings.smooth_initial:
             p0_params = p0.params[..., 0]
             p0_params = jnp.expand_dims(smooth(p0_params), -1)
             p0 = p0.replace_params(p0_params)
@@ -592,7 +641,7 @@ def simulate_wave_propagation(
         return [p, u, rho], sensors(p, u, rho)
 
     # Define the scanning function according to the checkpoint type
-    if checkpoint:
+    if settings.checkpoint:
         scan_fun = jax_checkpoint(scan_fun)
 
     logger.debug("Starting simulation using FourierSeries code")

--- a/jwave/acoustics/time_varying.py
+++ b/jwave/acoustics/time_varying.py
@@ -48,6 +48,7 @@ class TimeWavePropagationSettings(Module):
     ...    c_ref = lambda m: m.min_sound_speed)
     >>> print(settings.checkpoint)
     True
+
     ```
     """
 

--- a/jwave/acoustics/time_varying.py
+++ b/jwave/acoustics/time_varying.py
@@ -22,7 +22,7 @@ from jax import numpy as jnp
 from jax.lax import scan
 from jaxdf import Field, operator
 from jaxdf.discretization import FourierSeries, Linear, OnGrid
-from jaxdf.mods import JaxDFModule
+from jaxdf.mods import Module
 from jaxdf.operators import diag_jacobian, shift_operator, sum_over_dims
 
 from jwave.acoustics.spectral import kspace_op
@@ -35,7 +35,7 @@ from .pml import td_pml_on_grid
 Any = TypeVar("Any")
 
 
-class TimeWavePropagationSettings(JaxDFModule):
+class TimeWavePropagationSettings(Module):
     """
     TimeWavePropagationSettings configures the settings for
     time domain wave solvers. This class serves as a container

--- a/jwave/geometry.py
+++ b/jwave/geometry.py
@@ -49,9 +49,9 @@ class Medium(JaxDFModule):
         _type_: _description_
     """
     domain: Domain
-    sound_speed: Union[FourierSeries, Field, float]
-    density: Union[FourierSeries, Field, float]
-    attenuation: Union[FourierSeries, Field, float]
+    sound_speed: Union[Array, Field, float]
+    density: Union[Array, Field, float]
+    attenuation: Union[Array, Field, float]
     pml_size: float = eqx.field(default=20.0, static=True)
 
     def __init__(self,

--- a/jwave/geometry.py
+++ b/jwave/geometry.py
@@ -115,6 +115,84 @@ class Medium(JaxDFModule):
                 f"The type parameter of a Medium object must be a subclass of Field. Got {t}"
             )
 
+    @property
+    def max_sound_speed(self):
+        """
+        Calculate and return the maximum sound speed.
+
+        This property uses the `sound_speed` method/function and applies the `amax`
+        function from JAX's numpy (jnp) library to find the maximum sound speed value.
+
+        Returns:
+            The maximum sound speed value.
+        """
+        return functional(self.sound_speed)(jnp.amax)
+
+    @property
+    def min_sound_speed(self):
+        """
+        Calculate and return the minimum sound speed.
+
+        This property uses the `sound_speed` method/function and applies the `amin`
+        function from JAX's numpy (jnp) library to find the minimum sound speed value.
+
+        Returns:
+            The minimum sound speed value.
+        """
+        return functional(self.sound_speed)(jnp.amin)
+
+    @property
+    def max_density(self):
+        """
+        Calculate and return the maximum density.
+
+        This property uses the `density` method/function and applies the `amax`
+        function from JAX's numpy (jnp) library to find the maximum density value.
+
+        Returns:
+            The maximum density value.
+        """
+        return functional(self.density)(jnp.amax)
+
+    @property
+    def min_density(self):
+        """
+        Calculate and return the minimum density.
+
+        This property uses the `density` method/function and applies the `amin`
+        function from JAX's numpy (jnp) library to find the minimum density value.
+
+        Returns:
+            The minimum density value.
+        """
+        return functional(self.density)(jnp.amin)
+
+    @property
+    def max_attenuation(self):
+        """
+        Calculate and return the maximum attenuation.
+
+        This property uses the `attenuation` method/function and applies the `amax`
+        function from JAX's numpy (jnp) library to find the maximum attenuation value.
+
+        Returns:
+            The maximum attenuation value.
+        """
+        return functional(self.attenuation)(jnp.amax)
+
+    @property
+    def min_attenuation(self):
+        """
+        Calculate and return the minimum attenuation.
+
+        This property uses the `attenuation` method/function and applies the `amin`
+        function from JAX's numpy (jnp) library to find the minimum attenuation value.
+
+        Returns:
+            The minimum attenuation value.
+        """
+        return functional(self.attenuation)(jnp.amin)
+
     @classmethod
     def __infer_type_parameter__(self, *args, **kwargs):
         """Inter the type parameter from the arguments. Defaults to FourierSeries if

--- a/jwave/geometry.py
+++ b/jwave/geometry.py
@@ -23,7 +23,7 @@ from jax import numpy as jnp
 from jax.tree_util import register_pytree_node_class
 from jaxdf import Field, FourierSeries
 from jaxdf.geometry import Domain
-from jaxdf.mods import JaxDFModule
+from jaxdf.mods import Module
 from jaxdf.operators import dot_product, functional
 from jaxtyping import Array
 from plum import parametric
@@ -34,7 +34,7 @@ Number = Union[float, int]
 
 
 @parametric
-class Medium(JaxDFModule):
+class Medium(Module):
     """_summary_
 
     Args:

--- a/jwave/logger.py
+++ b/jwave/logger.py
@@ -1,0 +1,40 @@
+import logging
+
+# Initialize the logger
+logger = logging.getLogger(__name__.split(".")[0])
+logger.setLevel(logging.INFO)
+
+# Create a console handler
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+
+# Create a formatter and add it to the handler
+formatter = logging.Formatter(
+    '%(asctime)s - %(name)s [%(levelname)s]: %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S')
+ch.setFormatter(formatter)
+
+# Add the handler to the logger
+logger.addHandler(ch)
+
+
+# Function to set logging level
+def set_logging_level(level: int) -> None:
+    """
+    Set the logging level for both the logger and all its handlers.
+
+    This function updates the logging level of the logger to the specified
+    level and also iterates through all the handlers associated with the logger,
+    updating their logging levels to match the specified level.
+
+    Parameters:
+    level (int): An integer representing the logging level. This should be one
+                 of the logging level constants defined in the logging module, such as
+                 logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, or logging.CRITICAL.
+
+    Returns:
+    None
+    """
+    logger.setLevel(level)
+    for handler in logger.handlers:
+        handler.setLevel(level)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-jaxdf = "^0.2.4"
+jaxdf = "^0.2.7"
 matplotlib = "^3.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/acoustics/test_simulate_wave_propagation.py
+++ b/tests/acoustics/test_simulate_wave_propagation.py
@@ -1,0 +1,44 @@
+import logging
+from io import StringIO
+
+from jax import numpy as jnp
+
+from jwave.acoustics import simulate_wave_propagation
+from jwave.geometry import Domain, FourierSeries, Medium, TimeAxis
+from jwave.logger import logger, set_logging_level
+
+
+def test_correct_call():
+    domain = Domain((100, ), (1., ))
+    fs = FourierSeries(jnp.ones((100, )), domain)
+    medium = Medium(domain, sound_speed=fs)
+    p0 = FourierSeries(jnp.zeros((100, )), domain)
+    tax = TimeAxis.from_medium(medium)
+    tax.t_end = 1.0
+
+    # Create a StringIO object to capture log output
+    log_capture_string = StringIO()
+    ch = logging.StreamHandler(log_capture_string)
+
+    # Add the custom handler to the logger
+    logger.addHandler(ch)
+    set_logging_level(logging.DEBUG)
+
+    # Run the function
+    p = simulate_wave_propagation(medium, tax, p0=p0)
+
+    # Remove the handler after capturing the logs
+    logger.removeHandler(ch)
+
+    # Get the log output from the StringIO object
+    log_contents = log_capture_string.getvalue()
+
+    # Restore logging level
+    set_logging_level(logging.INFO)
+
+    # Perform assertions on the log contents
+    assert "Starting simulation using FourierSeries code" in log_contents
+
+
+if __name__ == "__main__":
+    test_correct_call()

--- a/tests/geometry/test_geometry.py
+++ b/tests/geometry/test_geometry.py
@@ -51,7 +51,6 @@ def testfibonacci_sphere():
 
 
 if __name__ == "__main__":
-    test_repr()
     testpoints_on_circle()
     testunit_fibonacci_sphere()
     testfibonacci_sphere()

--- a/tests/geometry/test_geometry.py
+++ b/tests/geometry/test_geometry.py
@@ -1,27 +1,7 @@
 import numpy as np
-from jax import numpy as jnp
 
-from jwave.geometry import (Domain, Medium, fibonacci_sphere, points_on_circle,
+from jwave.geometry import (fibonacci_sphere, points_on_circle,
                             unit_fibonacci_sphere)
-
-
-def test_repr():
-    # Create Domain object. Replace with correct constructor based on your implementation.
-    domain = Domain()
-
-    N = (8, 9)
-    medium = Medium(domain=domain,
-                    sound_speed=jnp.ones(N),
-                    density=jnp.ones(N),
-                    attenuation=0.0,
-                    pml_size=15)
-
-    expected_output = "Medium:\n - domain: {}\n - sound_speed: {}\n - density: {}\n - attenuation: {}\n - pml_size: {}".format(
-        str(medium.domain), str(medium.sound_speed), str(medium.density),
-        str(medium.attenuation), str(medium.pml_size))
-
-    # Check that the __repr__ method output matches the expected output
-    assert str(medium) == expected_output
 
 
 def testpoints_on_circle():
@@ -68,3 +48,10 @@ def testfibonacci_sphere():
                                        (y[i] - centre[1])**2 +
                                        (z[i] - centre[2])**2)
         assert np.isclose(distance_from_centre, radius, atol=1e-5)
+
+
+if __name__ == "__main__":
+    test_repr()
+    testpoints_on_circle()
+    testunit_fibonacci_sphere()
+    testfibonacci_sphere()

--- a/tests/geometry/test_medium.py
+++ b/tests/geometry/test_medium.py
@@ -1,0 +1,51 @@
+import pytest
+from jax import numpy as jnp
+
+from jwave import FourierSeries, OnGrid
+from jwave.geometry import Domain, Medium
+
+
+# Tests for Medium class
+def test_medium_type_with_fourier_series():
+    domain = Domain((10, ), (1., ))
+    fs = FourierSeries(jnp.zeros((10, )), domain)
+
+    m = Medium(domain, sound_speed=fs)
+    assert isinstance(
+        m, Medium[FourierSeries]), "Type should be Medium[FourierSeries]"
+
+    m = Medium(domain, sound_speed=fs, density=10.0)
+    assert isinstance(
+        m, Medium[FourierSeries]), "Type should be Medium[FourierSeries]"
+
+    m = Medium(domain)
+    assert isinstance(
+        m, Medium[FourierSeries]), "Type should be Medium[FourierSeries]"
+
+
+def test_medium_type_with_on_grid():
+    domain = Domain((10, ), (1., ))
+    params = jnp.ones((10, ))
+    fd = OnGrid(params, domain)
+
+    m = Medium(domain, density=fd)
+    assert isinstance(m, Medium[OnGrid]), "Type should be Medium[OnGrid]"
+
+
+def test_medium_type_mismatch():
+    domain = Domain((10, ), (1., ))
+    fs = FourierSeries(jnp.zeros((10, )), domain)
+    params = jnp.ones((10, ))
+    fd = OnGrid(params, domain)
+
+    with pytest.raises(ValueError):
+        m = Medium(domain, sound_speed=fs, density=fd)
+
+    with pytest.raises(TypeError):
+        m = Medium[int](domain, sound_speed=fs)
+
+
+if __name__ == "__main__":
+    test_medium_type_with_fourier_series()
+    test_medium_type_with_on_grid()
+    test_medium_type_mismatch()

--- a/tests/test_kwave_3d_ivp.py
+++ b/tests/test_kwave_3d_ivp.py
@@ -25,7 +25,8 @@ from matplotlib import pyplot as plt
 from scipy.io import loadmat, savemat
 
 from jwave import FourierSeries
-from jwave.acoustics import simulate_wave_propagation
+from jwave.acoustics import (TimeWavePropagationSettings,
+                             simulate_wave_propagation)
 from jwave.geometry import Domain, Medium, TimeAxis, sphere_mask
 from jwave.utils import plot_comparison
 
@@ -135,14 +136,17 @@ def test_ivp(test_name, use_plots=False):
     )
     time_axis = TimeAxis.from_medium(medium, cfl=0.5, t_end=2.5e-6)
 
+    # Define simulation settings
+    sim_settings = TimeWavePropagationSettings(
+        smooth_initial=settings["smooth_initial"])
+
     # Run simulation
     @partial(jit, backend="cpu")
     def run_simulation(p0):
-        return simulate_wave_propagation(
-            medium,
-            time_axis,
-            p0=p0,
-            smooth_initial=settings["smooth_initial"])
+        return simulate_wave_propagation(medium,
+                                         time_axis,
+                                         p0=p0,
+                                         settings=sim_settings)
 
     # Extract last field
     p_final = run_simulation(p0)[-1].on_grid[..., 0]

--- a/tests/test_kwave_ivp.py
+++ b/tests/test_kwave_ivp.py
@@ -25,7 +25,8 @@ from matplotlib import pyplot as plt
 from scipy.io import loadmat, savemat
 
 from jwave import FourierSeries
-from jwave.acoustics import simulate_wave_propagation
+from jwave.acoustics import (TimeWavePropagationSettings,
+                             simulate_wave_propagation)
 from jwave.geometry import Domain, Medium, TimeAxis, circ_mask
 from jwave.utils import plot_comparison
 
@@ -219,14 +220,17 @@ def test_ivp(test_name, use_plots=False):
     )
     time_axis = TimeAxis.from_medium(medium, cfl=0.5, t_end=5e-6)
 
+    # Define simulation settings
+    sim_settings = TimeWavePropagationSettings(
+        smooth_initial=settings["smooth_initial"])
+
     # Run simulation
     @partial(jit, backend="cpu")
     def run_simulation(p0):
-        return simulate_wave_propagation(
-            medium,
-            time_axis,
-            p0=p0,
-            smooth_initial=settings["smooth_initial"])
+        return simulate_wave_propagation(medium,
+                                         time_axis,
+                                         p0=p0,
+                                         settings=sim_settings)
 
     # Extract last field
     p_final = run_simulation(p0)[-1].on_grid[:, :, 0]

--- a/tests/test_kwave_ivp_fd.py
+++ b/tests/test_kwave_ivp_fd.py
@@ -25,7 +25,8 @@ from matplotlib import pyplot as plt
 from scipy.io import loadmat, savemat
 
 from jwave import FiniteDifferences
-from jwave.acoustics import simulate_wave_propagation
+from jwave.acoustics import (TimeWavePropagationSettings,
+                             simulate_wave_propagation)
 from jwave.geometry import Domain, Medium, TimeAxis, circ_mask
 from jwave.utils import plot_comparison
 
@@ -151,14 +152,17 @@ def test_ivp(test_name, use_plots=False):
     )
     time_axis = TimeAxis.from_medium(medium, cfl=0.1, t_end=4e-6)
 
+    # Define simulation settings
+    sim_settings = TimeWavePropagationSettings(
+        smooth_initial=settings["smooth_initial"])
+
     # Run simulation
     @partial(jit, backend="cpu")
     def run_simulation(p0):
-        return simulate_wave_propagation(
-            medium,
-            time_axis,
-            p0=p0,
-            smooth_initial=settings["smooth_initial"])
+        return simulate_wave_propagation(medium,
+                                         time_axis,
+                                         p0=p0,
+                                         settings=sim_settings)
 
     # Extract last field
     p_final = run_simulation(p0)[-1].on_grid[:, :, 0]


### PR DESCRIPTION
Moving to new `jaxdf` version, which is based on `equinox` and the latest major `plum` release.

Others changes:
- Added logger #214
- Fixes #218
- Added a setting class for time domain simulations. This fixes #219 and will be used to choose the adjoint type when jwave is integrated with diffrax